### PR TITLE
Remove hardcoded directory name

### DIFF
--- a/wp-h5p-xapi.php
+++ b/wp-h5p-xapi.php
@@ -19,10 +19,10 @@ Version: 0.1.6
 
 function h5pxapi_enqueue_scripts()
 {
-    wp_register_script("wp-h5p-xapi", plugins_url() . "/wp-h5p-xapi/wp-h5p-xapi.js", array("jquery"));
+    wp_register_script("wp-h5p-xapi", plugins_url("/wp-h5p-xapi.js", __FILE__), array("jquery"));
     wp_enqueue_script("wp-h5p-xapi");
 
-    wp_register_style("wp-h5p-xapi", plugins_url() . "/wp-h5p-xapi/wp-h5p-xapi.css");
+    wp_register_style("wp-h5p-xapi", plugins_url("/wp-h5p-xapi.css", __FILE__));
     wp_enqueue_style("wp-h5p-xapi");
 
     $xapi_js_settings = array();
@@ -84,7 +84,7 @@ function h5pxapi_admin_init() {
  */
 function h5pxapi_create_settings_page()
 {
-    wp_register_style("wp-h5p-xapi", plugins_url() . "/wp-h5p-xapi/wp-h5p-xapi.css");
+    wp_register_style("wp-h5p-xapi", plugins_url("/wp-h5p-xapi/wp-h5p-xapi.css", __FILE__));
     wp_enqueue_style("wp-h5p-xapi");
 
     $template = new Template(__DIR__ . "/src/template/settings.tpl.php");


### PR DESCRIPTION
The plugin's directory name is hardcoded into the source code. That was okay when the plugin was still available in the WordPress plugin repository, but when people simply download it from github, the archive name and thus the folder name will contain -master (or the branch in general) at the end and the plugin won't work.